### PR TITLE
fix: add default time_increment=1 for async insights queries (SUPPORT-13890)

### DIFF
--- a/src/page_loader.py
+++ b/src/page_loader.py
@@ -51,9 +51,10 @@ class PageLoader:
             logging.info("Adding default time_increment=1 to async insights query to ensure daily breakdown")
 
         logging.info(f"Starting async insights request: {endpoint_path}")
+        logging.info(f"Async insights params: {params}")
 
         try:
-            response = self.client.post(endpoint_path=endpoint_path, json=params)
+            response = self.client.post(endpoint_path=endpoint_path, data=params)
             report_id = response.get("report_run_id")
             if not report_id:
                 logging.warning("No 'report_run_id' found in the async insights response.")

--- a/src/page_loader.py
+++ b/src/page_loader.py
@@ -171,6 +171,13 @@ class PageLoader:
                 until_part = fields.split(".until(")[1].split(")")[0]
                 params["until"] = get_past_date(until_part.strip()).strftime("%Y-%m-%d")
 
+            has_period = "period" in params
+            has_date_range = "since" in params or "until" in params
+
+            if not has_period and has_date_range:
+                params["period"] = "day"
+                logging.info("Adding default period=day to sync insights query to ensure daily breakdown")
+
         else:
             # Regular queries use the 'fields' parameter directly
             if query_config.fields:

--- a/src/page_loader.py
+++ b/src/page_loader.py
@@ -42,6 +42,14 @@ class PageLoader:
             param_pairs = (p.split("=", 1) for p in query_config.parameters.split("&") if "=" in p)
             params.update({k.strip(): v.strip() for k, v in param_pairs})
 
+        has_time_increment = "time_increment" in params
+        has_date_preset = "date_preset" in params
+        has_time_ranges = "time_ranges" in params
+
+        if not has_time_increment and (has_date_preset or has_time_ranges):
+            params["time_increment"] = "1"
+            logging.info("Adding default time_increment=1 to async insights query to ensure daily breakdown")
+
         logging.info(f"Starting async insights request: {endpoint_path}")
 
         try:


### PR DESCRIPTION
# fix: async and sync insights extraction issues (SUPPORT-13890, SUPPORT-14107)

## Summary
Fixes multiple related issues in Facebook Ads V2 extractor affecting insights queries:

1. **Single row instead of daily breakdown** (SUPPORT-13890): When migrating from V1 to V2, insights queries returned only one aggregated row instead of daily breakdown. Fixed by adding default `time_increment=1` for async insights and default `period=day` for sync insights when date ranges are specified but granularity parameters are missing.

2. **Missing metrics in async extraction** (SUPPORT-14107): Async insights queries returned empty metric columns (impressions, reach, clicks, spend) and empty ad_name. Root cause: parameters were sent as JSON body (`json=params`) but Facebook Graph API expects form-encoded data. Fixed by changing to `data=params`.

3. **Added debug logging** for async insights params to aid troubleshooting.

**Changes:**
- `start_async_insights_job`: Add default `time_increment=1` when `date_preset`/`time_ranges` present but `time_increment` missing
- `start_async_insights_job`: Change `client.post(json=params)` to `client.post(data=params)` to send form-encoded params
- `_build_params`: Add default `period=day` for sync insights when date range present but `period` missing
- Add debug logging for async insights params

## Review & Testing Checklist for Human
- [ ] **Test with customer config (SUPPORT-13890)** - Run V2 config `keboola.ex-facebook-ads-v2/01k838c8dsq9b9486adfh06hvy` in project 16710 and verify it returns multiple daily rows instead of a single aggregated row (this was the original sync insights issue)
- [ ] **Test with customer config (SUPPORT-14107)** - Run async insights extraction and verify metric columns (impressions, reach, clicks, spend) and ad_name are populated with actual values, not empty
- [ ] **Verify both extraction paths work** - Test both async insights queries (with `date_preset`/`time_ranges`) and sync insights queries (with `since`/`until` in fields) to ensure both return correct daily breakdown
- [ ] **Check for regressions** - Verify that queries with explicit `time_increment` or `period` parameters continue to work as before and aren't overridden by the defaults
- [ ] **Test edge cases** - Try partial date ranges (only `since` or only `until`), different `date_preset` values, and alternative date specifications to ensure the logic is robust

### Test Plan
1. Run the customer's V2 config from SUPPORT-13890 (sync insights with date range) and verify output has multiple daily rows with populated metrics
2. Run an async insights query with `date_preset=last_7d` (without explicit `time_increment`) and verify daily breakdown with populated metrics
3. Test with explicit `time_increment=7` or `period=week` to ensure custom values are respected and not overridden

### Notes
- **Could not test against actual Facebook API** - The fixes are based on code analysis, comparison with V1 behavior, and Facebook API documentation. Production testing with real customer configs is critical.
- **Parameter encoding change** - Switching from JSON body to form-encoded data for async insights jobs is a significant change that could have edge case implications. Monitor for any unexpected behavior.
- **CI deployment steps were skipped** - CI passed all checks, but deployment steps show as "skipping" in CI logs, so a test deployment may be needed before production rollout.
- Initial PR only fixed async insights; sync insights fix was added after Olena clarified the customer uses `fields="insights.metric(...)"` syntax
- The parameter encoding issue (json vs data) was discovered by investigating why metrics were empty even after the time_increment fix

**Session info:**
- Link to Devin run: https://app.devin.ai/sessions/ba5f299de7c542508063dd738ea15433
- Requested by: zdenek.srotyr@keboola.com (@ZdenekSrotyr)