### PR TITLE
fix(SUPPORT-14169): re-raise HTTP errors during pagination instead of swallowing them

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -62,6 +62,7 @@ class FacebookClient:
         self.client = HttpClient(
             base_url="https://graph.facebook.com",
             default_http_header={"Content-Type": "application/json"},
+            status_forcelist=(500, 502, 503, 504),
         )
 
     def _with_token(self, params: dict, token: str = None) -> dict:

--- a/src/page_loader.py
+++ b/src/page_loader.py
@@ -224,9 +224,10 @@ class PageLoader:
             return response if response else {"data": []}
 
         except HTTPError as e:
-            logging.error(f"HTTP error while loading paginated data from URL {url}: {e.response.text}")
-            return {"data": []}
+            status_code = getattr(getattr(e, "response", None), "status_code", None)
+            logging.error(f"HTTP error while loading paginated data (status={status_code}): {e}")
+            raise
 
         except Exception as e:
             logging.error(f"Failed to load paginated data from URL {url}: {str(e)}")
-            return {"data": []}
+            raise


### PR DESCRIPTION
## Summary

Fixes an issue where HTTP errors (like 503 Service Unavailable) during pagination were silently swallowed, causing jobs to complete successfully but with missing data.

**Root cause**: The `load_page_from_url` method was catching HTTP errors and returning `{"data": []}` instead of re-raising them. This caused the pagination loop to break silently, dropping all subsequent pages.

**Changes:**
- `page_loader.py`: Re-raise `HTTPError` and `Exception` instead of returning empty data
- `client.py`: Add 503 to `status_forcelist` so transient errors are automatically retried (was missing - only 500, 502, 504 were retried)
- Improved error logging to show status code without dumping full HTML response body

## Review & Testing Checklist for Human

- [ ] **Verify behavior change is acceptable**: Jobs that previously succeeded with missing data will now fail on HTTP errors during pagination. This is intentional per SUPPORT-14169 but may affect existing workflows.
- [ ] **Test with a configuration that hits pagination**: Run a Facebook Ads extraction that fetches multiple pages of data to verify pagination still works correctly
- [ ] **Test error handling**: Verify that transient 503 errors are retried (up to 10 times with backoff) before failing

### Notes

Related Jira: [SUPPORT-14169](https://keboola.atlassian.net/browse/SUPPORT-14169)

The customer reported that jobs completed successfully but showed error messages in logs and had missing data. The old component (`keboola.ex-facebook-ads`) didn't exhibit this issue because it likely had different error handling.

Link to Devin run: https://app.devin.ai/sessions/43cf7198b6104359a5bf79099ef93f18
Requested by: zdenek.srotyr@keboola.com (@ZdenekSrotyr)

[SUPPORT-14169]: https://keboola.atlassian.net/browse/SUPPORT-14169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ