### PR TITLE
fix(SUPPORT-14352): add act_ prefix for sync insights queries

### DIFF
--- a/src/page_loader.py
+++ b/src/page_loader.py
@@ -182,12 +182,19 @@ class PageLoader:
         return params
 
     def _build_endpoint_path(self, query_config, page_id: str) -> str:
+        # Check if this is an insights query
+        fields = str(getattr(query_config, "fields", ""))
+        is_insights_query = not query_config.path and fields.startswith("insights")
+
+        # For insights queries, normalize page_id to include act_ prefix (like async path does)
+        # This is required for Facebook Ads API ad account insights endpoints
+        if is_insights_query and page_id and not page_id.startswith("act_"):
+            page_id = f"act_{page_id}"
+
         # Start with the API version
         path_parts = [self.api_version, page_id]
 
-        # Check if this is an insights query
-        fields = str(getattr(query_config, "fields", ""))
-        if not query_config.path and fields.startswith("insights"):
+        if is_insights_query:
             path_parts.append("insights")
         elif query_config.path:
             path_parts.append(query_config.path)


### PR DESCRIPTION
## Summary

Fixes 400 Bad Request errors when using sync extraction for ad account insights queries. The sync path in `_build_endpoint_path` was missing the `act_` prefix normalization that the async path already has in `start_async_insights_job` (line 37).

**Before**: Sync insights queries built URLs like `/v20.0/120234840950110406/insights`
**After**: Sync insights queries now build URLs like `/v20.0/act_120234840950110406/insights`

The fix only applies when:
- `query_config.path` is not set AND
- `fields` starts with "insights"

This matches the existing condition used to detect insights queries in this method.

## Review & Testing Checklist for Human

- [ ] **Verify Facebook Page insights still work**: This fix adds `act_` prefix for all sync insights queries. Facebook Page insights (not ad account insights) should NOT have `act_` prefix. Need to confirm whether Page insights go through this code path or use a different flow.
- [ ] **Test with the failing configuration from SUPPORT-14352**: Run the component with the exact configuration that was failing (campaign endpoint with sync insights) to confirm the fix resolves the 400 error.
- [ ] **Compare with async path behavior**: Verify that `start_async_insights_job` (line 37) has the same `act_` prefix logic and that mirroring it here is correct.

### Recommended Test Plan
1. Configure a Facebook Ads V2 extractor with sync insights query for an ad account
2. Run the component and verify no 400 error occurs
3. Check logs to confirm the endpoint URL includes `act_` prefix
4. If possible, also test with a Facebook Page insights query to ensure it still works

### Notes
- Related Jira ticket: [SUPPORT-14352](https://keboola.atlassian.net/browse/SUPPORT-14352)
- Link to Devin run: https://app.devin.ai/sessions/d083ab8ab9654a8d8d079976186058b8
- Requested by: zdenek.srotyr@keboola.com (@ZdenekSrotyr)

[SUPPORT-14352]: https://keboola.atlassian.net/browse/SUPPORT-14352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ