### PR TITLE
fix(SUPPORT-14169): preserve API version in pagination URLs

### DIFF
--- a/src/page_loader.py
+++ b/src/page_loader.py
@@ -201,15 +201,13 @@ class PageLoader:
         try:
             parsed_url = urlparse(url)
 
-            # Extract the path (remove the base URL part)
+            # Extract the path - keep the API version if present in the URL
             # URL format: https://graph.facebook.com/v19.0/path?params
             path = parsed_url.path
 
-            # Remove the version prefix if present (e.g., /v19.0/)
-            if path.startswith("/v"):
-                path_parts = path.split("/", 3)
-                if len(path_parts) > 2:
-                    path = "/" + "/".join(path_parts[2:])
+            # If the URL doesn't include an API version, prepend our configured version
+            if not path.startswith("/v"):
+                path = f"/{self.api_version}{path}"
 
             # Parse query parameters
             query_params = parse_qs(parsed_url.query)

--- a/src/page_loader.py
+++ b/src/page_loader.py
@@ -197,17 +197,11 @@ class PageLoader:
     def load_page_from_url(self, url: str) -> dict[str, Any]:
         """
         Load page data from a full Facebook API URL (used for pagination).
+        Respects the paging.next URL as returned by the Facebook API.
         """
         try:
             parsed_url = urlparse(url)
-
-            # Extract the path - keep the API version if present in the URL
-            # URL format: https://graph.facebook.com/v19.0/path?params
             path = parsed_url.path
-
-            # If the URL doesn't include an API version, prepend our configured version
-            if not path.startswith("/v"):
-                path = f"/{self.api_version}{path}"
 
             # Parse query parameters
             query_params = parse_qs(parsed_url.query)


### PR DESCRIPTION
## Summary

**Problem:** `load_page_from_url` in `page_loader.py` was stripping the API version from pagination URLs, causing 400 errors:
```
GET /120234374693150023/insights → 400 Bad Request
```

**Root cause:** The code intentionally removed `/v23.0/` prefix from `paging.next` URLs. This was a bug - the original Clojure extractor passed full URLs directly without stripping. Without a version, Facebook uses the App Dashboard default, which may differ from the user's config.

**Fix:** Removed the version stripping logic entirely. Now we respect the `paging.next` URL path as returned by the Facebook API.

## Updates since last revision

Based on reviewer feedback, simplified the fix further:
- Removed the version prepending logic (was overcorrection)
- Now just uses the path from `paging.next` as-is without any manipulation
- The API knows what it's doing - we should trust it

## Tested

https://connection.us-east4.gcp.keboola.com/admin/projects/4214/components/keboola.ex-facebook-ads-v2/01kadqbd62hszsgebv2rj5dw2s
https://connection.eu-central-1.keboola.com/admin/projects/3482/branch/15201/components/keboola.ex-facebook-ads-v2/01k8t4nh3ky59v34q0my26mj5g
https://connection.us-east4.gcp.keboola.com/admin/projects/4214/components/keboola.ex-facebook-ads-v2/01kb049tnwyzv0vmws5dv7r90c
https://keboola.atlassian.net/browse/SUPPORT-14389

## Review & Testing Checklist for Human

- [ ] **Test sync extraction with nested insights** (e.g., `campaigns` with `insights{...}` fields) that returns multiple pages - verify pagination requests now include the API version in logs
- [ ] **Verify pagination works for Facebook Pages V2 and Instagram V2** - this `PageLoader` is shared across all three components

### Meta Behavior
When you make a Graph API call without specifying a version in the URL path, Facebook calls this an "unversioned call". Instead of failing, Facebook uses a fallback version configured in your App Dashboard under Settings > Advanced > Upgrade API Version.

For example:

Versioned call: https://graph.facebook.com/v23.0/{user-id} → uses v23.0

Unversioned call: https://graph.facebook.com/{user-id} → uses version from App Dashboard (e.g., v2.10)

Facebook explicitly recommends: "We recommend you always specify the version where possible."

Why this matters for our component: If pagination URLs lose the version prefix, the API version used for pagination may differ from the version used for the initial request, leading to inconsistent behavior or errors.

Documentation: https://developers.facebook.com/docs/graph-api/guides/versioning/#what-happens-if-i-don-t-specify-a-version-for-an-api-

### Notes

Related Jira: [SUPPORT-14169](https://keboola.atlassian.net/browse/SUPPORT-14169)
and https://keboolaglobal.slack.com/archives/C021XUHSE4T/p1764116102149199

Link to Devin run: https://app.devin.ai/sessions/43cf7198b6104359a5bf79099ef93f18
Requested by: zdenek.srotyr@keboola.com (@ZdenekSrotyr)

[SUPPORT-14169]: https://keboola.atlassian.net/browse/SUPPORT-14169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ