### PR TITLE
fix(SUPPORT-14431): handle empty accounts list in sync actions

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -87,7 +87,9 @@ class Component(ComponentBase):
     def __init__(self):
         super().__init__()
         self._writer_cache: dict[str, WriterCacheRecord] = {}
-        self.config = Configuration(**self.configuration.parameters)
+        params = self.configuration.parameters
+        params["accounts"] = params.get("accounts") or {}
+        self.config = Configuration(**params)
         self.client: FacebookClient = FacebookClient(self.configuration.oauth_credentials, self.config.api_version)
         self.bucket_id = self._retrieve_bucket_id()
 


### PR DESCRIPTION
## Summary

Fixes the "Add Accounts" button failing with Internal Server Error in Facebook Ads V2 extractor when no accounts are configured yet.

**Root cause:** When the sync action `adaccounts` is triggered, the UI sends `"accounts": []` (empty list), but the `Configuration` Pydantic model expects `accounts: dict[str, Account]`, causing a validation error.

**Fix:** Use `or {}` to convert an empty list to an empty dict before passing to the Configuration model.

## Review & Testing Checklist for Human

- [ ] Verify that mutating `params["accounts"]` doesn't cause side effects if `self.configuration.parameters` is referenced elsewhere
- [ ] Test the "Add Accounts" button in the FB Ads V2 extractor UI on a configuration with no accounts to confirm the fix works end-to-end
- [ ] Confirm that existing configurations with accounts still work correctly after this change

**Recommended test plan:**
1. Go to the affected project: https://connection.north-europe.azure.keboola.com/admin/projects/15636/components/keboola.ex-facebook-ads-v2/
2. Create a new configuration or use one with no accounts
3. Click "Add Accounts" button and verify it no longer returns Internal Server Error

### Notes

- Related ticket: [SUPPORT-14431](https://keboola.atlassian.net/browse/SUPPORT-14431)
- Link to Devin run: https://app.devin.ai/sessions/76ec113542a5418c8b6f7d371c393c59
- Requested by: martin.struzsky@keboola.com (@soustruh)

[SUPPORT-14431]: https://keboola.atlassian.net/browse/SUPPORT-14431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ