### PR TITLE
fix(SUPPORT-14107): robust action breakdown detection and DSL parsing

### DIFF
--- a/src/output_parser.py
+++ b/src/output_parser.py
@@ -55,10 +55,15 @@ class OutputParser:
     def _is_action_breakdown_query(self) -> bool:
         """
         Check if this is an action breakdown query (action_reaction or action_type).
-        Handles both string parameters (query string format) and dict parameters.
+        Handles string parameters, dict parameters, and DSL-style fields.
         """
         query = self.row_config.query
         parameters = getattr(query, "parameters", None)
+        fields = str(getattr(query, "fields", "") or "")
+
+        # Check DSL-style fields (e.g., "insights.action_breakdowns(action_type)")
+        if ".action_breakdowns(action_type)" in fields or ".action_breakdowns(action_reaction)" in fields:
+            return True
 
         if not parameters:
             return False

--- a/src/output_parser.py
+++ b/src/output_parser.py
@@ -392,32 +392,31 @@ class OutputParser:
                 self._add_row(result, table_name, action_row)
 
     def _copy_common_fields(self, base_row: dict, original_row: dict, extended: bool) -> None:
-        fields = [
-            "account_id",
-            "ad_id",
-            "adset_id",
-            "campaign_id",
-            "date_start",
-            "date_stop",
-            "publisher_platform",
-        ]
+        """
+        Copy fields from original_row to base_row.
+        Following Clojure approach: when extended=True, copy ALL scalar fields.
+        """
         if extended:
-            # Include names and metric fields for action breakdown queries
-            # These fields were missing in V2 output causing empty columns (SUPPORT-14107)
-            fields += [
-                "account_name",
-                "campaign_name",
-                "ad_name",
-                "adset_name",
-                "impressions",
-                "clicks",
-                "spend",
-                "reach",
+            # Clojure approach: copy all scalar fields from original_row
+            # This automatically includes any field that Facebook API returns
+            for key, value in original_row.items():
+                # Skip complex types (lists, dicts) - those are handled separately
+                if not isinstance(value, (list, dict)):
+                    base_row[key] = value
+        else:
+            # Basic fields for non-action-breakdown queries
+            fields = [
+                "account_id",
+                "ad_id",
+                "adset_id",
+                "campaign_id",
+                "date_start",
+                "date_stop",
+                "publisher_platform",
             ]
-
-        for field in fields:
-            if field in original_row:
-                base_row[field] = original_row[field]
+            for field in fields:
+                if field in original_row:
+                    base_row[field] = original_row[field]
 
     def _populate_action_row(
         self,

--- a/src/output_parser.py
+++ b/src/output_parser.py
@@ -56,15 +56,9 @@ class OutputParser:
         """
         Check if this is an action breakdown query (action_reaction or action_type).
         Handles both string parameters (query string format) and dict parameters.
-        Also checks DSL-style fields string for .action_breakdowns() syntax.
         """
         query = self.row_config.query
         parameters = getattr(query, "parameters", None)
-        fields = str(getattr(query, "fields", "") or "")
-
-        # Check DSL-style fields string (e.g., "insights.action_breakdowns(action_type)")
-        if ".action_breakdowns(action_type)" in fields or ".action_breakdowns(action_reaction)" in fields:
-            return True
 
         if not parameters:
             return False
@@ -84,34 +78,6 @@ class OutputParser:
         if isinstance(parameters, dict):
             action_breakdowns = parameters.get("action_breakdowns", "")
             return action_breakdowns in ["action_type", "action_reaction"]
-
-        return False
-
-    def _has_action_reaction_breakdown(self) -> bool:
-        """Check if this query uses action_reaction breakdown specifically."""
-        query = self.row_config.query
-        parameters = getattr(query, "parameters", None)
-        fields = str(getattr(query, "fields", "") or "")
-
-        # Check DSL-style fields string
-        if ".action_breakdowns(action_reaction)" in fields:
-            return True
-
-        if not parameters:
-            return False
-
-        # Handle string parameters
-        if isinstance(parameters, str):
-            try:
-                parsed = parse_qs(parameters)
-                action_breakdowns = parsed.get("action_breakdowns", [])
-                return "action_reaction" in action_breakdowns
-            except Exception:
-                return "action_breakdowns=action_reaction" in parameters
-
-        # Handle dict parameters
-        if isinstance(parameters, dict):
-            return parameters.get("action_breakdowns") == "action_reaction"
 
         return False
 
@@ -438,12 +404,9 @@ class OutputParser:
             }
         )
 
-        if is_action_breakdown and self._has_action_reaction_breakdown():
-            action_reaction = action.get("action_reaction", original_row.get("action_reaction", ""))
-            action_row["action_reaction"] = action_reaction
-
+        # Copy all other fields from action (Clojure approach - just include what's in data)
         for key, value in action.items():
-            if key not in ["action_type", "value", "action_reaction"]:
+            if key not in ["action_type", "value"]:
                 action_row[key] = value
 
     def _get_action_stats_table_name(self, stats_field_name: str) -> str:

--- a/src/output_parser.py
+++ b/src/output_parser.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import Any, Optional
 from collections.abc import Iterator
+from urllib.parse import parse_qs
 
 
 class OutputParser:
@@ -50,6 +51,69 @@ class OutputParser:
         self.page_loader = page_loader
         self.page_id = page_id
         self.row_config = row_config
+
+    def _is_action_breakdown_query(self) -> bool:
+        """
+        Check if this is an action breakdown query (action_reaction or action_type).
+        Handles both string parameters (query string format) and dict parameters.
+        Also checks DSL-style fields string for .action_breakdowns() syntax.
+        """
+        query = self.row_config.query
+        parameters = getattr(query, "parameters", None)
+        fields = str(getattr(query, "fields", "") or "")
+
+        # Check DSL-style fields string (e.g., "insights.action_breakdowns(action_type)")
+        if ".action_breakdowns(action_type)" in fields or ".action_breakdowns(action_reaction)" in fields:
+            return True
+
+        if not parameters:
+            return False
+
+        # Handle string parameters (query string format)
+        if isinstance(parameters, str):
+            try:
+                parsed = parse_qs(parameters)
+                action_breakdowns = parsed.get("action_breakdowns", [])
+                return any(v in ["action_type", "action_reaction"] for v in action_breakdowns)
+            except Exception:
+                # Fallback to substring match if parsing fails
+                return ("action_breakdowns=action_type" in parameters
+                        or "action_breakdowns=action_reaction" in parameters)
+
+        # Handle dict parameters
+        if isinstance(parameters, dict):
+            action_breakdowns = parameters.get("action_breakdowns", "")
+            return action_breakdowns in ["action_type", "action_reaction"]
+
+        return False
+
+    def _has_action_reaction_breakdown(self) -> bool:
+        """Check if this query uses action_reaction breakdown specifically."""
+        query = self.row_config.query
+        parameters = getattr(query, "parameters", None)
+        fields = str(getattr(query, "fields", "") or "")
+
+        # Check DSL-style fields string
+        if ".action_breakdowns(action_reaction)" in fields:
+            return True
+
+        if not parameters:
+            return False
+
+        # Handle string parameters
+        if isinstance(parameters, str):
+            try:
+                parsed = parse_qs(parameters)
+                action_breakdowns = parsed.get("action_breakdowns", [])
+                return "action_reaction" in action_breakdowns
+            except Exception:
+                return "action_breakdowns=action_reaction" in parameters
+
+        # Handle dict parameters
+        if isinstance(parameters, dict):
+            return parameters.get("action_breakdowns") == "action_reaction"
+
+        return False
 
     def parse_data(
         self,
@@ -117,10 +181,7 @@ class OutputParser:
         full_row_data = {**base_row, **processed_data["regular_fields"]}
 
         # Check if this is an action breakdown query (action_reaction or action_type)
-        is_action_breakdown_query = hasattr(self.row_config.query, "parameters") and (
-            "action_breakdowns=action_reaction" in str(self.row_config.query.parameters)
-            or "action_breakdowns=action_type" in str(self.row_config.query.parameters)
-        )
+        is_action_breakdown_query = self._is_action_breakdown_query()
 
         # For action breakdown queries, only create main row if there are no action stats to process
         # Otherwise, actions become the main rows
@@ -303,13 +364,7 @@ class OutputParser:
         result: dict[str, list[dict[str, Any]]],
     ) -> None:
         """Process action stats as separate tables with _insights suffix or flatten for breakdowns."""
-        is_action_breakdown = hasattr(self.row_config.query, "parameters") and any(
-            b in str(self.row_config.query.parameters)
-            for b in [
-                "action_breakdowns=action_reaction",
-                "action_breakdowns=action_type",
-            ]
-        )
+        is_action_breakdown = self._is_action_breakdown_query()
 
         for stats_field_name, stats_data in action_stats.items():
             if not isinstance(stats_data, list):
@@ -347,7 +402,18 @@ class OutputParser:
             "publisher_platform",
         ]
         if extended:
-            fields += ["account_name", "campaign_name"]
+            # Include names and metric fields for action breakdown queries
+            # These fields were missing in V2 output causing empty columns (SUPPORT-14107)
+            fields += [
+                "account_name",
+                "campaign_name",
+                "ad_name",
+                "adset_name",
+                "impressions",
+                "clicks",
+                "spend",
+                "reach",
+            ]
 
         for field in fields:
             if field in original_row:
@@ -373,7 +439,7 @@ class OutputParser:
             }
         )
 
-        if is_action_breakdown and "action_breakdowns=action_reaction" in str(self.row_config.query.parameters):
+        if is_action_breakdown and self._has_action_reaction_breakdown():
             action_reaction = action.get("action_reaction", original_row.get("action_reaction", ""))
             action_row["action_reaction"] = action_reaction
 

--- a/src/output_parser.py
+++ b/src/output_parser.py
@@ -179,11 +179,16 @@ class OutputParser:
 
     def _create_base_row(self, fb_graph_node: str, parent_id: str) -> dict[str, Any]:
         """Create base row with standard metadata."""
-        return {
+        base_row = {
             "ex_account_id": self.page_id,
             "fb_graph_node": fb_graph_node,
             "parent_id": parent_id,
         }
+        # For Ads accounts, derive account_id from page_id (like Clojure does)
+        # Facebook API doesn't return account_id when explicit fields are specified
+        if self.page_id and self.page_id.startswith("act_"):
+            base_row["account_id"] = self.page_id[4:]  # Strip "act_" prefix
+        return base_row
 
     def _process_fields(self, row: dict[str, Any]) -> dict[str, Any]:
         """Process all fields in a row and categorize them."""

--- a/src/page_loader.py
+++ b/src/page_loader.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -142,52 +143,30 @@ class PageLoader:
         fields = str(getattr(query_config, "fields", ""))
         # Insights queries have special parameter handling
         if not query_config.path and fields.startswith("insights"):
-            # Extract 'metric' from the 'fields' string (e.g., "insights.metric(page_fans)")
-            if ".metric(" in fields:
-                metric_part = fields.split(".metric(")[1].split(")")[0]
-                metrics = [m.strip() for m in metric_part.replace("\n", "").split(",") if m.strip()]
-                if metrics:
-                    params["metric"] = ",".join(metrics)
+            # Generic extraction of all .X(Y) patterns from DSL
+            # This automatically handles any DSL parameter without needing individual handlers
+            dsl_pattern = re.compile(r'\.(\w+)\(([^)]+)\)', re.DOTALL)
+            for match in dsl_pattern.finditer(fields):
+                param_name = match.group(1)
+                param_value = match.group(2).strip()
 
-            # Extract 'period' from the 'fields' string (e.g., "insights.period(day)")
-            if ".period(" in fields:
-                period_part = fields.split(".period(")[1].split(")")[0]
-                params["period"] = period_part.strip()
-
-            # Extract and convert 'since' from the 'fields' string (e.g., "insights.since(90 days ago)")
-            if ".since(" in fields:
-                since_part = fields.split(".since(")[1].split(")")[0]
-                params["since"] = get_past_date(since_part.strip()).strftime("%Y-%m-%d")
-
-            # Extract and convert 'until' from the 'fields' string (e.g., "insights.until(2 days ago)")
-            if ".until(" in fields:
-                until_part = fields.split(".until(")[1].split(")")[0]
-                params["until"] = get_past_date(until_part.strip()).strftime("%Y-%m-%d")
-
-            # Extract 'level' (e.g., "insights.level(ad)")
-            if ".level(" in fields:
-                level_part = fields.split(".level(")[1].split(")")[0]
-                params["level"] = level_part.strip()
-
-            # Extract 'action_breakdowns' (e.g., "insights.action_breakdowns(action_type)")
-            if ".action_breakdowns(" in fields:
-                breakdown_part = fields.split(".action_breakdowns(")[1].split(")")[0]
-                params["action_breakdowns"] = breakdown_part.strip()
-
-            # Extract 'date_preset' (e.g., "insights.date_preset(last_3d)")
-            if ".date_preset(" in fields:
-                preset_part = fields.split(".date_preset(")[1].split(")")[0]
-                params["date_preset"] = preset_part.strip()
-
-            # Extract 'time_increment' (e.g., "insights.time_increment(1)")
-            if ".time_increment(" in fields:
-                increment_part = fields.split(".time_increment(")[1].split(")")[0]
-                params["time_increment"] = increment_part.strip()
+                # Special handling for date params - need conversion
+                if param_name in ('since', 'until'):
+                    params[param_name] = get_past_date(param_value).strftime("%Y-%m-%d")
+                # Special handling for metric - comma-separated list normalization
+                elif param_name == 'metric':
+                    metrics = [m.strip() for m in param_value.replace("\n", "").split(",") if m.strip()]
+                    if metrics:
+                        params[param_name] = ",".join(metrics)
+                else:
+                    # All other params (level, action_breakdowns, date_preset, period, etc.)
+                    # pass through directly - no special handling needed
+                    params[param_name] = param_value
 
             # Extract explicit fields list (e.g., "insights{ad_id,ad_name,clicks}")
-            if "{" in fields and "}" in fields:
-                fields_part = fields.split("{")[1].split("}")[0]
-                explicit_fields = [f.strip() for f in fields_part.split(",") if f.strip()]
+            fields_match = re.search(r'\{([^}]+)\}', fields)
+            if fields_match:
+                explicit_fields = [f.strip() for f in fields_match.group(1).split(",") if f.strip()]
                 if explicit_fields:
                     params["fields"] = ",".join(explicit_fields)
 

--- a/src/page_loader.py
+++ b/src/page_loader.py
@@ -164,6 +164,33 @@ class PageLoader:
                 until_part = fields.split(".until(")[1].split(")")[0]
                 params["until"] = get_past_date(until_part.strip()).strftime("%Y-%m-%d")
 
+            # Extract 'level' (e.g., "insights.level(ad)")
+            if ".level(" in fields:
+                level_part = fields.split(".level(")[1].split(")")[0]
+                params["level"] = level_part.strip()
+
+            # Extract 'action_breakdowns' (e.g., "insights.action_breakdowns(action_type)")
+            if ".action_breakdowns(" in fields:
+                breakdown_part = fields.split(".action_breakdowns(")[1].split(")")[0]
+                params["action_breakdowns"] = breakdown_part.strip()
+
+            # Extract 'date_preset' (e.g., "insights.date_preset(last_3d)")
+            if ".date_preset(" in fields:
+                preset_part = fields.split(".date_preset(")[1].split(")")[0]
+                params["date_preset"] = preset_part.strip()
+
+            # Extract 'time_increment' (e.g., "insights.time_increment(1)")
+            if ".time_increment(" in fields:
+                increment_part = fields.split(".time_increment(")[1].split(")")[0]
+                params["time_increment"] = increment_part.strip()
+
+            # Extract explicit fields list (e.g., "insights{ad_id,ad_name,clicks}")
+            if "{" in fields and "}" in fields:
+                fields_part = fields.split("{")[1].split("}")[0]
+                explicit_fields = [f.strip() for f in fields_part.split(",") if f.strip()]
+                if explicit_fields:
+                    params["fields"] = ",".join(explicit_fields)
+
         else:
             # Regular queries use the 'fields' parameter directly
             if query_config.fields:


### PR DESCRIPTION
# fix(SUPPORT-14107): robust action breakdown detection and DSL parsing

## Summary

Fixes Facebook Ads V2 action breakdown queries that were producing empty columns in output. The root cause was threefold:
1. Fragile action breakdown detection in output_parser.py that only worked with string parameters containing exact substring matches
2. Missing DSL parameter parsing in page_loader.py - sync insights queries using DSL syntax weren't sending required parameters to Facebook API
3. Missing `account_id` in output when explicit fields are specified in DSL (Facebook API doesn't return it automatically)

**Changes in output_parser.py:**
- Added `_is_action_breakdown_query()` helper that properly handles:
  - String parameters (query string format like `action_breakdowns=action_type`)
  - Dict parameters
  - DSL-style fields string (`.action_breakdowns(action_type)` syntax)
- Uses `urllib.parse.parse_qs` for proper query string parsing with fallback
- Refactored `_copy_common_fields(extended=True)` to follow Clojure V1 approach: copy ALL scalar fields from original_row instead of maintaining an explicit field list
- Simplified `_populate_action_row()` to copy all fields from action data (Clojure approach)
- Removed `_has_action_reaction_breakdown()` helper - `action_reaction` is now included automatically if present in data
- **Added `account_id` derivation from `page_id`** in `_create_base_row()` for Ads accounts (strips `act_` prefix)

**Changes in page_loader.py:**
- Replaced individual DSL handlers with a **generic regex extractor** that automatically forwards any `.X(Y)` pattern as `X=Y` parameter
- Only special handling for:
  - `since/until`: date conversion via `get_past_date()`
  - `metric`: comma-separated list normalization
- All other params (`level`, `action_breakdowns`, `date_preset`, `period`, `time_increment`, etc.) pass through directly
- Extracts `{field1,field2,...}` → `fields=field1,field2,...` via regex
- **Future-proof**: any new DSL pattern automatically gets forwarded without code changes

## Updates since last revision

**Added `account_id` fallback** - Test job 152495554 failed with "Missing columns: account_id" because Facebook API doesn't return `account_id` when explicit fields are specified in DSL. Following Clojure approach: derive `account_id` from the query context (`page_id`) by stripping the `act_` prefix for Ads accounts.

## Review & Testing Checklist for Human

- [ ] **Re-test with actual customer config** (project 15170) - previous tests failed. Must verify sync query now produces expected columns including `account_id`
- [ ] **Verify `account_id` format is correct** - the fix strips `act_` prefix (e.g., `act_123456` → `123456`). Confirm this matches what the output mapping/schema expects
- [ ] **Verify regex handles edge cases** - the pattern `[^)]+` won't handle nested parentheses. Check for configs where DSL values might contain `)` characters
- [ ] **Verify no regression for Facebook Pages and Instagram** - this component serves all three (FB Ads, Pages, IG). The `account_id` derivation only triggers when `page_id` starts with `act_`
- [ ] **Test async queries still work** - page_loader.py changes only affect `_build_params()` used by sync queries

**Recommended test plan:**
1. Deploy new branch tag to test config in project 15170
2. Run the customer's sync extraction query with `action_breakdowns=action_type`
3. Verify output table has populated values for: `account_id`, ad_name, clicks, impressions, spend, reach
4. Run a basic Facebook Pages or Instagram query to verify no regression
5. Run an async insights query to verify no regression

### Notes

- No unit tests were added (existing tests have environment import issues unrelated to this PR)
- Related to existing draft PRs #22 and #23 which have broader changes
- Test jobs 152490220, 152490752 failed before page_loader.py DSL parsing was added
- Test job 152495554 failed with missing `account_id` - addressed in latest commit

Link to Devin run: https://app.devin.ai/sessions/d820bdbb1686427f81b3777a37f3fc2d
Requested by: zdenek.srotyr@keboola.com (@ZdenekSrotyr)