### PR TITLE
fix: add OAuth credentials validation to prevent internal errors

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -55,9 +55,23 @@ class FacebookClient:
         self.api_version = api_version
         self.page_tokens = None  # Cache for page tokens
 
-        if self.oauth.data and self.oauth.data.get("token", None) and not self.oauth.data.get("access_token", None):
+        # Validate OAuth credentials are present
+        if not self.oauth or not self.oauth.data:
+            raise UserException(
+                "Missing OAuth credentials. Please authorize the component with your Facebook account "
+                "in the component configuration."
+            )
+
+        if self.oauth.data.get("token", None) and not self.oauth.data.get("access_token", None):
             logging.info("Direct insert token is used for authentication.")
             self.oauth.data["access_token"] = self.oauth.data["token"]
+
+        # Validate that we have an access token
+        if not self.oauth.data.get("access_token"):
+            raise UserException(
+                "Missing access token in OAuth credentials. Please re-authorize the component "
+                "with your Facebook account in the component configuration."
+            )
 
         self.client = HttpClient(
             base_url="https://graph.facebook.com",


### PR DESCRIPTION
## Summary

Adds validation for OAuth credentials in `FacebookClient.__init__` to convert cryptic internal errors into clear user-facing error messages.

**Root cause**: When OAuth credentials are missing or incomplete, the code was accessing `self.oauth.data` without checking if `self.oauth` is `None`, resulting in `'NoneType' object has no attribute 'data'` which surfaced as an internal error (exit code 2) instead of a user configuration error.

**Fix**: Added explicit validation checks that raise `UserException` with helpful messages guiding users to re-authorize their Facebook account.

## Review & Testing Checklist for Human

- [ ] Verify the error messages are appropriate for end users (not too technical, actionable)
- [ ] Test with a configuration that has missing `authorization.oauth_api` section to confirm the first validation triggers correctly
- [ ] Test with a configuration that has OAuth credentials but no access token to confirm the second validation triggers correctly
- [ ] Confirm existing configurations with valid OAuth credentials still work (regression test)

**Recommended test plan**: Run the component locally with a `config.json` that has an empty or missing `authorization` section and verify you get a clear `UserException` message instead of an internal error.

### Notes

- The original error was observed in Datadog for project 343, config `01kctx51jn8c1rkykb8pxsx1yx`
- Only 1 unit test exists in this repo, so manual testing is recommended
- Link to Devin run: https://app.devin.ai/sessions/002ea32865514ba58678271fdd6ba077
- Requested by: zdenek.srotyr@keboola.com (@ZdenekSrotyr)