### PR TITLE
fix: add validation for missing OAuth credentials

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -51,11 +51,16 @@ for name in logging.root.manager.loggerDict:
 
 class FacebookClient:
     def __init__(self, oauth: OauthCredentials, api_version: str):
+        if not oauth or not oauth.data:
+            raise UserException(
+                "Missing OAuth credentials. Please authorize the component in the Keboola Connection UI."
+            )
+
         self.oauth = oauth
         self.api_version = api_version
         self.page_tokens = None  # Cache for page tokens
 
-        if self.oauth.data and self.oauth.data.get("token", None) and not self.oauth.data.get("access_token", None):
+        if self.oauth.data.get("token", None) and not self.oauth.data.get("access_token", None):
             logging.info("Direct insert token is used for authentication.")
             self.oauth.data["access_token"] = self.oauth.data["token"]
 

--- a/src/component.py
+++ b/src/component.py
@@ -90,7 +90,19 @@ class Component(ComponentBase):
         params = self.configuration.parameters
         params["accounts"] = params.get("accounts") or {}
         self.config = Configuration(**params)
-        self.client: FacebookClient = FacebookClient(self.configuration.oauth_credentials, self.config.api_version)
+
+        oauth = self.configuration.oauth_credentials
+        if not oauth or not oauth.data:
+            raise UserException(
+                "Missing OAuth credentials. Please authorize the component in the Keboola Connection UI."
+            )
+        if not oauth.data.get("access_token") and not oauth.data.get("token"):
+            raise UserException(
+                "Missing access token in OAuth credentials. Please re-authorize the component in the Keboola "
+                "Connection UI."
+            )
+
+        self.client: FacebookClient = FacebookClient(oauth, self.config.api_version)
         self.bucket_id = self._retrieve_bucket_id()
 
     def run(self) -> None:


### PR DESCRIPTION
## Summary

Fixes internal error `'NoneType' object has no attribute 'data'` that occurs when the component runs without proper OAuth authorization. The error was triggered because `self.configuration.oauth_credentials` can return `None` when the authorization block is missing from config.json, and this was passed directly to `FacebookClient` without validation.

**Changes:**
- Added validation in `Component.__init__` to check for OAuth credentials and access token before creating `FacebookClient`
- Added defensive check in `FacebookClient.__init__` as belt-and-suspenders
- Both raise `UserException` with clear user-facing messages instead of cryptic internal errors

**Root cause:** Datadog logs showed jobs failing with exit code 2 (application error) due to missing OAuth credentials in the configuration.

## Review & Testing Checklist for Human

- [ ] **Test with missing authorization block** - Run component with a config.json that has no `authorization` section and verify it shows the user-friendly error message instead of internal error
- [ ] **Test with empty credentials** - Run with `authorization.oauth_api.credentials` present but empty/missing `#data`
- [ ] **Test normal operation** - Verify a properly configured component still works correctly
- [ ] **Verify sync actions** - Test that `accounts`, `adaccounts`, `igaccounts` sync actions still work (they also run through `Component.__init__`)

### Notes

- No automated tests were run (pytest not in venv, docker tests not executed) - only verified code imports successfully
- The validation in `component.py` is more comprehensive (checks for access_token/token), while `client.py` only checks for oauth/oauth.data presence

**Link to Devin run:** https://app.devin.ai/sessions/f105aa063f8c48a7925dcb9bad1e0ca0
**Requested by:** zdenek.srotyr@keboola.com (@ZdenekSrotyr)