### PR TITLE
fix: add OAuth credentials validation to prevent AttributeError

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -90,8 +90,31 @@ class Component(ComponentBase):
         params = self.configuration.parameters
         params["accounts"] = params.get("accounts") or {}
         self.config = Configuration(**params)
-        self.client: FacebookClient = FacebookClient(self.configuration.oauth_credentials, self.config.api_version)
+        self._validate_oauth_credentials()
+        self.client: FacebookClient = FacebookClient(
+            self.configuration.oauth_credentials, self.config.api_version
+        )
         self.bucket_id = self._retrieve_bucket_id()
+
+    def _validate_oauth_credentials(self) -> None:
+        """Validate that OAuth credentials are properly configured."""
+        oauth = self.configuration.oauth_credentials
+        if oauth is None:
+            raise UserException(
+                "Missing OAuth authorization. Please configure the component authorization "
+                "in the Keboola UI by clicking 'Authorize' to connect your Facebook account."
+            )
+        if oauth.data is None:
+            raise UserException(
+                "Invalid OAuth authorization data. Please re-authorize the component "
+                "in the Keboola UI by clicking 'Authorize' to reconnect your Facebook account."
+            )
+        # Check for access_token or token (direct insert token)
+        if not oauth.data.get("access_token") and not oauth.data.get("token"):
+            raise UserException(
+                "Missing access token in OAuth authorization. Please re-authorize the component "
+                "in the Keboola UI or provide a valid access token using the direct token method."
+            )
 
     def run(self) -> None:
         self._write_accounts_from_config(self.config)
@@ -114,7 +137,9 @@ class Component(ComponentBase):
                 "fb_page_id": acc.fb_page_id,
             }
             # filter None values
-            accounts_data.append(dict(filter(lambda x: x[1] is not None, account_dict.items())))
+            accounts_data.append(
+                dict(filter(lambda x: x[1] is not None, account_dict.items()))
+            )
 
         if accounts_data:
             self._write_rows("accounts", accounts_data, ["id"], False)
@@ -127,13 +152,17 @@ class Component(ComponentBase):
 
         logging.info(f"Processing {len(queries_to_process)} queries.")
 
-        for parsed_data in self.client.process_queries(list(config.accounts.values()), queries_to_process):
+        for parsed_data in self.client.process_queries(
+            list(config.accounts.values()), queries_to_process
+        ):
             for table_name, rows_list in parsed_data.items():
                 if not rows_list:
                     continue
                 primary_key = self._get_primary_key(rows_list)
                 self._write_rows(table_name, rows_list, primary_key, True)
-                logging.debug(f"Wrote batch of {len(rows_list)} rows to table {table_name}")
+                logging.debug(
+                    f"Wrote batch of {len(rows_list)} rows to table {table_name}"
+                )
 
     def _finalize_tables(self) -> None:
         for cache_record in self._writer_cache.values():
@@ -171,11 +200,15 @@ class Component(ComponentBase):
             all_columns_set.update(row.keys())
 
         # Reorder columns based on preferred order, then add remaining sorted
-        ordered_columns = [col for col in PREFERRED_COLUMNS_ORDER if col in all_columns_set]
+        ordered_columns = [
+            col for col in PREFERRED_COLUMNS_ORDER if col in all_columns_set
+        ]
         remaining_columns = sorted(all_columns_set - set(PREFERRED_COLUMNS_ORDER))
         all_columns = ordered_columns + remaining_columns
 
-        logging.debug(f"Creating table definition for {table_name} with destination {self.bucket_id}.{table_name}")
+        logging.debug(
+            f"Creating table definition for {table_name} with destination {self.bucket_id}.{table_name}"
+        )
         table_def = self.create_out_table_definition(
             f"{table_name}.csv",
             primary_key=primary_key,
@@ -184,7 +217,9 @@ class Component(ComponentBase):
         )
 
         writer = ElasticDictWriter(table_def.full_path, all_columns)
-        self._writer_cache[table_name] = WriterCacheRecord(writer=writer, table_definition=table_def)
+        self._writer_cache[table_name] = WriterCacheRecord(
+            writer=writer, table_definition=table_def
+        )
 
     def _get_primary_key(self, rows: list[dict[str, Any]]) -> list[str]:
         if not rows:
@@ -193,7 +228,9 @@ class Component(ComponentBase):
         available_columns: set[str] = set()
         for row in rows:
             available_columns.update(row.keys())
-        primary_key = [col for col in PRIMARY_KEY_CANDIDATES if col in available_columns]
+        primary_key = [
+            col for col in PRIMARY_KEY_CANDIDATES if col in available_columns
+        ]
         return primary_key or (["id"] if "id" in available_columns else [])
 
     def _retrieve_bucket_id(self) -> str:
@@ -208,7 +245,9 @@ class Component(ComponentBase):
             config_id = datetime.now().strftime("%Y%m%d%H%M%S")
         if not component_id:
             component_id = "keboola-ex-meta"
-        logging.info(f"Using default bucket: in.c-{component_id.replace('.', '-')}-{config_id}")
+        logging.info(
+            f"Using default bucket: in.c-{component_id.replace('.', '-')}-{config_id}"
+        )
         return f"in.c-{component_id.replace('.', '-')}-{config_id}"
 
     @sync_action("accounts")
@@ -217,11 +256,15 @@ class Component(ComponentBase):
 
     @sync_action("adaccounts")
     def run_ad_accounts_action(self) -> list[dict[str, Any]]:
-        return self.client.get_accounts("me/adaccounts", "account_id,id,business_name,name,currency")
+        return self.client.get_accounts(
+            "me/adaccounts", "account_id,id,business_name,name,currency"
+        )
 
     @sync_action("igaccounts")
     def run_ig_accounts_action(self) -> list[dict[str, Any]]:
-        return self.client.get_accounts("me/accounts", "instagram_business_account,name,category")
+        return self.client.get_accounts(
+            "me/accounts", "instagram_business_account,name,category"
+        )
 
 
 """


### PR DESCRIPTION
## Summary

Adds early validation of OAuth credentials in `Component.__init__` to prevent the component from crashing with an unhelpful `'NoneType' object has no attribute 'data'` error when OAuth authorization is missing or invalid.

The component now raises a clear `UserException` with actionable guidance in three cases:
- `oauth_credentials` is `None` (missing authorization)
- `oauth.data` is `None` (invalid authorization data)  
- `oauth.data` missing both `access_token` and `token` keys

This converts internal errors (exit code 2) to user errors (exit code 1) with helpful messages directing users to re-authorize in the Keboola UI.

**Root cause**: Datadog logs showed `keboola.ex-facebook-ads-v2` failing with `'NoneType' object has no attribute 'data'` in `client.py:58` when accessing `self.oauth.data` without validation.

## Review & Testing Checklist for Human

- [ ] Verify the error messages are accurate for Keboola UI (references to "Authorize" button)
- [ ] Test with a configuration missing OAuth authorization to confirm `UserException` is raised instead of `AttributeError`
- [ ] Confirm sync_actions (`accounts`, `adaccounts`, `igaccounts`) should also require OAuth validation (they use the client which needs credentials)

### Notes

The diff also includes cosmetic line-wrapping changes from `ruff format` - the actual logic change is only the new `_validate_oauth_credentials()` method and its call in `__init__`.

Link to Devin run: https://app.devin.ai/sessions/a35c7f826bfd4b658bf13936d90e8e6c
Requested by: zdenek.srotyr@keboola.com (@ZdenekSrotyr)