### PR TITLE
fix: handle RetryError as UserException to prevent application errors

### DIFF
--- a/src/page_loader.py
+++ b/src/page_loader.py
@@ -10,6 +10,7 @@ from keboola.component.exceptions import UserException
 from keboola.http_client import HttpClient
 from keboola.utils.date import get_past_date
 from requests import HTTPError
+from requests.exceptions import RetryError
 
 logger = logging.getLogger(__name__)
 
@@ -315,6 +316,12 @@ class PageLoader:
                 logger.error(f"Facebook API error response: {response.text}")
             raise
 
+        except RetryError as e:
+            raise UserException(
+                "Facebook API is temporarily unavailable (too many server errors). "
+                "Try again later or reduce the number of simultaneous configurations."
+            ) from e
+
         except Exception as e:
             logger.error(f"Failed to load page data: {e}")
             raise
@@ -449,6 +456,12 @@ class PageLoader:
             if response is not None:
                 logger.error(f"Facebook API error response: {response.text}")
             raise
+
+        except RetryError as e:
+            raise UserException(
+                "Facebook API is temporarily unavailable (too many server errors). "
+                "Try again later or reduce the number of simultaneous configurations."
+            ) from e
 
         except Exception as e:
             logger.error(f"Failed to load paginated data from URL {url}: {str(e)}")


### PR DESCRIPTION
## Summary
- Catch `requests.exceptions.RetryError` in `_load_regular_page` and `load_page_from_url` and convert to `UserException`
- Prevents unhandled application errors when Facebook API returns too many 500s (e.g. when many configurations run simultaneously)
- Avoids exposing the access token in the exception chain, which the platform would otherwise display in job logs

## Root cause
`HttpClient` is configured with `status_forcelist=(500, 502, 503, 504)`, so urllib3 automatically retries on 500s with exponential backoff (10 retries, factor 0.3). When all retries are exhausted, it raises `RetryError` — which is not an `HTTPError` and was slipping past all Facebook error handlers, then propagating unhandled through `output_parser._iter_paginated_responses` all the way to the platform as an application error.

## Test plan
- [ ] Run a configuration against a page that returns 500s to confirm the error now shows as a user-visible message rather than application error
- [ ] Confirm access token is not exposed in the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)