### PR TITLE
Use shared component-ci actions + fix metric_type DSL support (CFTL-464)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get push event info
         id: info
-        uses: keboola/component-ci/actions/push-event-info@master
+        uses: keboola/component-ci/actions/push-event-info@feature/source-image-input
 
   build:
     name: Docker Image Build
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build Docker image
-        uses: keboola/component-ci/actions/docker-build@master
+        uses: keboola/component-ci/actions/docker-build@feature/source-image-input
         with:
           app_id: ${{ env.KBC_DEVELOPERPORTAL_APP }}
 
@@ -68,7 +68,7 @@ jobs:
       - build
     steps:
       - name: Run KBC tests
-        uses: keboola/component-ci/actions/kbc-tests@master
+        uses: keboola/component-ci/actions/kbc-tests@feature/source-image-input
         with:
           app_id: ${{ env.KBC_DEVELOPERPORTAL_APP }}
           image_tag: ${{ needs.push_event_info.outputs.app_image_tag }}
@@ -90,12 +90,12 @@ jobs:
           - keboola.ex-instagram-v2
     steps:
       - name: Load Docker image
-        uses: keboola/component-ci/actions/docker-load@master
+        uses: keboola/component-ci/actions/docker-load@feature/source-image-input
         with:
           app_id: ${{ env.KBC_DEVELOPERPORTAL_APP }}
 
       - name: Push to ECR
-        uses: keboola/component-ci/actions/push-to-ecr@master
+        uses: keboola/component-ci/actions/push-to-ecr@feature/source-image-input
         with:
           app_id: ${{ matrix.app_id }}
           vendor: ${{ env.KBC_DEVELOPERPORTAL_VENDOR }}
@@ -122,7 +122,7 @@ jobs:
           - keboola.ex-instagram-v2
     steps:
       - name: Deploy
-        uses: keboola/component-ci/actions/deploy@master
+        uses: keboola/component-ci/actions/deploy@feature/source-image-input
         with:
           app_id: ${{ matrix.app_id }}
           vendor: ${{ env.KBC_DEVELOPERPORTAL_VENDOR }}
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Update properties
-        uses: keboola/component-ci/actions/update-properties@master
+        uses: keboola/component-ci/actions/update-properties@feature/source-image-input
         with:
           app_id: ${{ matrix.app_id }}
           vendor: ${{ env.KBC_DEVELOPERPORTAL_VENDOR }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,111 +1,39 @@
 name: Keboola Component Build & Deploy Pipeline
 on: [ push ]
-concurrency: ci-${{ github.ref }} # to avoid tag collisions in the ECR
+concurrency: ci-${{ github.ref }}
+
 env:
-  # repository variables:
-  KBC_DEVELOPERPORTAL_APP: "keboola.ex-facebook-pages" # replace with your component id
-  KBC_DEVELOPERPORTAL_APP_ADS: "keboola.ex-facebook-ads-v2"
-  KBC_DEVELOPERPORTAL_APP_INSTAGRAM: "keboola.ex-instagram-v2"
-  KBC_DEVELOPERPORTAL_VENDOR: "keboola" # replace with your vendor
-  DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-  KBC_DEVELOPERPORTAL_USERNAME: ${{ vars.KBC_DEVELOPERPORTAL_USERNAME }}
-
-  # repository secrets:
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }} # recommended for pushing to ECR
-  KBC_DEVELOPERPORTAL_PASSWORD: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-
-  # (Optional) Test KBC project: https://connection.keboola.com/admin/projects/0000
-  KBC_TEST_PROJECT_CONFIGS: "" # space separated list of config ids
-  KBC_STORAGE_TOKEN: ${{ secrets.KBC_STORAGE_TOKEN }} # required for running KBC tests
+  KBC_DEVELOPERPORTAL_APP: keboola.ex-facebook-pages
+  KBC_DEVELOPERPORTAL_VENDOR: keboola
+  KBC_TEST_PROJECT_CONFIGS: ""
 
 jobs:
   push_event_info:
     name: Push Event Info
     runs-on: ubuntu-latest
     outputs:
-      app_image_tag: ${{ steps.tag.outputs.app_image_tag }}
-      is_semantic_tag: ${{ steps.tag.outputs.is_semantic_tag }}
-      is_default_branch: ${{ steps.default_branch.outputs.is_default_branch }}
-      is_deploy_ready: ${{ steps.deploy_ready.outputs.is_deploy_ready }}
+      app_image_tag: ${{ steps.info.outputs.app_image_tag }}
+      is_deploy_ready: ${{ steps.info.outputs.is_deploy_ready }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Fetch all branches from remote repository
-        run: git fetch --prune --unshallow --tags -f
-
-      - name: Get current branch name
-        id: current_branch
-        run: |
-          if [[ ${{ github.ref }} != "refs/tags/"* ]]; then
-            branch_name=${{ github.ref_name }}
-            echo "branch_name=$branch_name" | tee -a $GITHUB_OUTPUT
-          else
-            raw=$(git branch -r --contains ${{ github.ref }})
-            branch="$(echo $raw | sed "s/.*origin\///" | tr -d '\n')"
-            echo "branch_name=$branch" | tee -a $GITHUB_OUTPUT
-          fi
-
-      - name: Is current branch the default branch
-        id: default_branch
-        run: |
-          echo "default_branch='${{ github.event.repository.default_branch }}'"
-          if [ "${{ github.event.repository.default_branch }}" = "${{ steps.current_branch.outputs.branch_name }}" ]; then
-             echo "is_default_branch=true" | tee -a $GITHUB_OUTPUT
-          else
-             echo "is_default_branch=false" | tee -a $GITHUB_OUTPUT
-          fi
-
-      - name: Set image tag
-        id: tag
-        run: |
-          REF="${GITHUB_REF##*/}"
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            TAG="$REF"
-          else
-            TAG="$REF-${{ github.run_number }}"
-          fi
-          IS_SEMANTIC_TAG=$(echo "$REF" | grep -q '^[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo true || echo false)
-          echo "is_semantic_tag=$IS_SEMANTIC_TAG" | tee -a $GITHUB_OUTPUT
-          echo "app_image_tag=$TAG" | tee -a $GITHUB_OUTPUT
-
-      - name: Deploy-Ready check
-        id: deploy_ready
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/* \
-            && "${{ steps.tag.outputs.is_semantic_tag }}" == "true" ]]; then
-                echo "is_deploy_ready=true" | tee -a $GITHUB_OUTPUT
-          else
-                echo "is_deploy_ready=false" | tee -a $GITHUB_OUTPUT
-          fi
+      - name: Get push event info
+        id: info
+        uses: keboola/component-ci/actions/push-event-info@master
 
   build:
     name: Docker Image Build
     runs-on: ubuntu-latest
-    needs:
-      - push_event_info
-    env:
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    needs: push_event_info
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
+      - name: Build Docker image
+        uses: keboola/component-ci/actions/docker-build@master
         with:
-          context: .
-          file: ./Dockerfile
-          tags: ${{ env.KBC_DEVELOPERPORTAL_APP }}:latest
-          outputs: type=docker,dest=/tmp/${{ env.KBC_DEVELOPERPORTAL_APP }}.tar
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.KBC_DEVELOPERPORTAL_APP }}
-          path: /tmp/${{ env.KBC_DEVELOPERPORTAL_APP }}.tar
+          app_id: ${{ env.KBC_DEVELOPERPORTAL_APP }}
 
   tests:
     name: Run Tests
@@ -114,13 +42,12 @@ jobs:
       - push_event_info
       - build
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      # Test image is built independently from production — ruff + pytest run at container start via CMD
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build test image
         uses: docker/build-push-action@v5
         with:
@@ -133,262 +60,97 @@ jobs:
       - name: Run Tests
         run: docker run ${{ env.KBC_DEVELOPERPORTAL_APP }}-test:latest
 
-  tests-kbc:
+  tests_kbc:
     name: Run KBC Tests
+    runs-on: ubuntu-latest
     needs:
       - push_event_info
       - build
-    runs-on: ubuntu-latest
     steps:
-      - name: Set up environment variables
-        run: |
-          echo "KBC_TEST_PROJECT_CONFIGS=${KBC_TEST_PROJECT_CONFIGS}" >> $GITHUB_ENV
-          echo "KBC_STORAGE_TOKEN=${{ secrets.KBC_STORAGE_TOKEN }}" >> $GITHUB_ENV
-
-      - name: Run KBC test jobs
-        if: env.KBC_TEST_PROJECT_CONFIGS != '' && env.KBC_STORAGE_TOKEN != ''
-        uses: keboola/action-run-configs-parallel@master
+      - name: Run KBC tests
+        uses: keboola/component-ci/actions/kbc-tests@master
         with:
-          token: ${{ secrets.KBC_STORAGE_TOKEN }}
-          componentId: ${{ env.KBC_DEVELOPERPORTAL_APP }}
-          tag: ${{ needs.push_event_info.outputs.app_image_tag }}
-          configs: ${{ env.KBC_TEST_PROJECT_CONFIGS }}
+          app_id: ${{ env.KBC_DEVELOPERPORTAL_APP }}
+          image_tag: ${{ needs.push_event_info.outputs.app_image_tag }}
+          kbc_test_configs: ${{ env.KBC_TEST_PROJECT_CONFIGS }}
+          kbc_storage_token: ${{ secrets.KBC_STORAGE_TOKEN }}
 
   push:
-    name: Docker Image Push
+    name: Push to ECR (${{ matrix.app_id }})
     runs-on: ubuntu-latest
     needs:
       - push_event_info
       - tests
-      - tests-kbc
-    env:
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      - tests_kbc
+    strategy:
+      matrix:
+        app_id:
+          - keboola.ex-facebook-pages
+          - keboola.ex-facebook-ads-v2
+          - keboola.ex-instagram-v2
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4
+      - name: Load Docker image
+        uses: keboola/component-ci/actions/docker-load@master
         with:
-          name: ${{ env.KBC_DEVELOPERPORTAL_APP }}
-          path: /tmp
-
-      - name: Load Image & Run Tests
-        run: |
-          docker load --input /tmp/${{ env.KBC_DEVELOPERPORTAL_APP }}.tar
-          docker image ls -a
-
-      - name: Docker login
-        if: env.DOCKERHUB_TOKEN
-        run: docker login --username "${{ env.DOCKERHUB_USER }}" --password "${{ env.DOCKERHUB_TOKEN }}"
-
-      - name: Push image to ECR
-        uses: keboola/action-push-to-ecr@master
-        with:
-          vendor: ${{ env.KBC_DEVELOPERPORTAL_VENDOR }}
           app_id: ${{ env.KBC_DEVELOPERPORTAL_APP }}
-          username: ${{ env.KBC_DEVELOPERPORTAL_USERNAME }}
-          password: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-          tag: ${{ needs.push_event_info.outputs.app_image_tag }}
-          push_latest: ${{ needs.push_event_info.outputs.is_deploy_ready }}
-          source_image: ${{ env.KBC_DEVELOPERPORTAL_APP }}
 
-
-  push-ad:
-    name: Docker Image Push - Ads
-    runs-on: ubuntu-latest
-    needs:
-      - push_event_info
-      - tests
-      - tests-kbc
-    env:
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4
+      - name: Push to ECR
+        uses: keboola/component-ci/actions/push-to-ecr@master
         with:
-          name: ${{ env.KBC_DEVELOPERPORTAL_APP }}
-          path: /tmp
-
-      - name: Load Image & Run Tests
-        run: |
-          docker load --input /tmp/${{ env.KBC_DEVELOPERPORTAL_APP }}.tar
-          docker image ls -a
-
-      - name: Docker login
-        if: env.DOCKERHUB_TOKEN
-        run: docker login --username "${{ env.DOCKERHUB_USER }}" --password "${{ env.DOCKERHUB_TOKEN }}"
-
-      - name: Push image to ECR
-        uses: keboola/action-push-to-ecr@master
-        with:
+          app_id: ${{ matrix.app_id }}
           vendor: ${{ env.KBC_DEVELOPERPORTAL_VENDOR }}
-          app_id: ${{ env.KBC_DEVELOPERPORTAL_APP_ADS }}
-          username: ${{ env.KBC_DEVELOPERPORTAL_USERNAME }}
-          password: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-          tag: ${{ needs.push_event_info.outputs.app_image_tag }}
-          push_latest: ${{ needs.push_event_info.outputs.is_deploy_ready }}
+          image_tag: ${{ needs.push_event_info.outputs.app_image_tag }}
+          is_deploy_ready: ${{ needs.push_event_info.outputs.is_deploy_ready }}
           source_image: ${{ env.KBC_DEVELOPERPORTAL_APP }}
-
-  push-instagram:
-    name: Docker Image Push - Instagram
-    runs-on: ubuntu-latest
-    needs:
-      - push_event_info
-      - tests
-      - tests-kbc
-    env:
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.KBC_DEVELOPERPORTAL_APP }}
-          path: /tmp
-
-      - name: Load Image & Run Tests
-        run: |
-          docker load --input /tmp/${{ env.KBC_DEVELOPERPORTAL_APP }}.tar
-          docker image ls -a
-
-      - name: Docker login
-        if: env.DOCKERHUB_TOKEN
-        run: docker login --username "${{ env.DOCKERHUB_USER }}" --password "${{ env.DOCKERHUB_TOKEN }}"
-
-      - name: Push image to ECR
-        uses: keboola/action-push-to-ecr@master
-        with:
-          vendor: ${{ env.KBC_DEVELOPERPORTAL_VENDOR }}
-          app_id: ${{ env.KBC_DEVELOPERPORTAL_APP_INSTAGRAM }}
-          username: ${{ env.KBC_DEVELOPERPORTAL_USERNAME }}
-          password: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-          tag: ${{ needs.push_event_info.outputs.app_image_tag }}
-          push_latest: ${{ needs.push_event_info.outputs.is_deploy_ready }}
-          source_image: ${{ env.KBC_DEVELOPERPORTAL_APP }}
+          dockerhub_user: ${{ secrets.DOCKERHUB_USER }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          kbc_developerportal_username: ${{ vars.KBC_DEVELOPERPORTAL_USERNAME }}
+          kbc_developerportal_password: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
 
   deploy:
-    name: Deploy to KBC
-    env:
-      KBC_DEVELOPERPORTAL_PASSWORD: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
+    name: Deploy (${{ matrix.app_id }})
+    runs-on: ubuntu-latest
     needs:
       - push_event_info
-      - build
       - push
     if: needs.push_event_info.outputs.is_deploy_ready == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app_id:
+          - keboola.ex-facebook-pages
+          - keboola.ex-facebook-ads-v2
+          - keboola.ex-instagram-v2
     steps:
-      - name: Set Developer Portal Tag
-        uses: keboola/action-set-tag-developer-portal@master
+      - name: Deploy
+        uses: keboola/component-ci/actions/deploy@master
         with:
+          app_id: ${{ matrix.app_id }}
           vendor: ${{ env.KBC_DEVELOPERPORTAL_VENDOR }}
-          app_id: ${{ env.KBC_DEVELOPERPORTAL_APP }}
-          username: ${{ env.KBC_DEVELOPERPORTAL_USERNAME }}
-          password: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-          tag: ${{ needs.push_event_info.outputs.app_image_tag }}
+          image_tag: ${{ needs.push_event_info.outputs.app_image_tag }}
+          kbc_developerportal_username: ${{ vars.KBC_DEVELOPERPORTAL_USERNAME }}
+          kbc_developerportal_password: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
 
-  update_developer_portal_properties:
-    name: Developer Portal Properties Update
-    env:
-      KBC_DEVELOPERPORTAL_PASSWORD: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
+  update_properties:
+    name: Update Properties (${{ matrix.app_id }})
+    runs-on: ubuntu-latest
     needs:
       - push_event_info
-      - build
       - push
-    runs-on: ubuntu-latest
     if: needs.push_event_info.outputs.is_deploy_ready == 'true'
+    strategy:
+      matrix:
+        app_id:
+          - keboola.ex-facebook-pages
+          - keboola.ex-facebook-ads-v2
+          - keboola.ex-instagram-v2
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Update developer portal properties
-        run: |
-          chmod +x scripts/developer_portal/*.sh
-          scripts/developer_portal/update_properties.sh
-
-  update_developer_portal_properties_ads:
-    name: Developer Portal Properties Update - Ads
-    env:
-      KBC_DEVELOPERPORTAL_PASSWORD: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-    needs:
-      - push_event_info
-      - build
-      - push-ad
-    runs-on: ubuntu-latest
-    if: needs.push_event_info.outputs.is_deploy_ready == 'true'
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Update developer portal properties
-        env:
-          KBC_DEVELOPERPORTAL_APP: ${{ env.KBC_DEVELOPERPORTAL_APP_ADS }}
-        run: |
-          chmod +x scripts/developer_portal/*.sh
-          scripts/developer_portal/update_properties.sh
-
-  update_developer_portal_properties_instagram:
-    name: Developer Portal Properties Update - Instagram
-    env:
-      KBC_DEVELOPERPORTAL_PASSWORD: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-    needs:
-      - push_event_info
-      - build
-      - push-instagram
-    runs-on: ubuntu-latest
-    if: needs.push_event_info.outputs.is_deploy_ready == 'true'
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Update developer portal properties
-        env:
-          KBC_DEVELOPERPORTAL_APP: ${{ env.KBC_DEVELOPERPORTAL_APP_INSTAGRAM }}
-        run: |
-          chmod +x scripts/developer_portal/*.sh
-          scripts/developer_portal/update_properties.sh
-
-  deploy-ad:
-    name: Deploy to KBC - Ads
-    env:
-      KBC_DEVELOPERPORTAL_PASSWORD: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-    needs:
-      - push_event_info
-      - build
-      - push-ad
-    if: needs.push_event_info.outputs.is_deploy_ready == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set Developer Portal Tag
-        uses: keboola/action-set-tag-developer-portal@master
+      - name: Update properties
+        uses: keboola/component-ci/actions/update-properties@master
         with:
+          app_id: ${{ matrix.app_id }}
           vendor: ${{ env.KBC_DEVELOPERPORTAL_VENDOR }}
-          app_id: ${{ env.KBC_DEVELOPERPORTAL_APP_ADS }}
-          username: ${{ env.KBC_DEVELOPERPORTAL_USERNAME }}
-          password: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-          tag: ${{ needs.push_event_info.outputs.app_image_tag }}
-
-  deploy-instagram:
-    name: Deploy to KBC - Instagram
-    env:
-      KBC_DEVELOPERPORTAL_PASSWORD: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-    needs:
-      - push_event_info
-      - build
-      - push-instagram
-    if: needs.push_event_info.outputs.is_deploy_ready == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set Developer Portal Tag
-        uses: keboola/action-set-tag-developer-portal@master
-        with:
-          vendor: ${{ env.KBC_DEVELOPERPORTAL_VENDOR }}
-          app_id: ${{ env.KBC_DEVELOPERPORTAL_APP_INSTAGRAM }}
-          username: ${{ env.KBC_DEVELOPERPORTAL_USERNAME }}
-          password: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}
-          tag: ${{ needs.push_event_info.outputs.app_image_tag }}
+          kbc_developerportal_username: ${{ vars.KBC_DEVELOPERPORTAL_USERNAME }}
+          kbc_developerportal_password: ${{ secrets.KBC_DEVELOPERPORTAL_PASSWORD }}


### PR DESCRIPTION
## Summary
- Replaces 395-line `push.yml` with ~130 lines using composite actions from `keboola/component-ci`
- Uses `strategy: matrix` for push/deploy/update-properties across 3 app IDs (facebook-pages, facebook-ads-v2, instagram-v2)
- **Fixes CFTL-464**: Adds `metric_type` to `DSL_SIMPLE_PARAMS` so Instagram Graph API v23.0 `metric_type(total_value)` is correctly parsed from the Fields DSL
- **Converts `INVALID_METRIC_ERROR` from silent empty data → `UserException`** with actionable message, so misconfigured queries fail loudly instead of producing empty output

## Key changes

### CI/CD (`push.yml`)
- 9 separate push/deploy/update jobs → 3 matrix jobs
- Inline workflow steps → shared composite actions from `keboola/component-ci`
- Test build still uses separate `test` Docker target (component-specific)

### Bug fix (`page_loader.py`) — CFTL-464
- Added `metric_type` to `DSL_SIMPLE_PARAMS` — previously silently dropped, causing API error #100
- Moved `INVALID_METRIC_ERROR` from recoverable (returns `{"data": []}`) to user-actionable (raises `UserException` with fix instructions)
- Both `_load_regular_page` and `load_page_from_url` now call `raise_if_user_actionable()` before checking recoverable errors

## Test plan
- [x] All 20 existing tests pass
- [ ] Pipeline passes on this branch
- [ ] All 3 app IDs pushed to ECR correctly
- [ ] Deploy and properties update work for all 3 components
- [ ] Customer can use `insights.period(day).metric_type(total_value).metric(reach,...)` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)